### PR TITLE
fix typos

### DIFF
--- a/data/com.vixalien.muzika.gschema.xml
+++ b/data/com.vixalien.muzika.gschema.xml
@@ -3,7 +3,7 @@
 	<schema id="com.vixalien.muzika" path="/com/vixalien/muzika/">
 		<key name="prefer-list" type="b">
 			<default>false</default>
-			<summary>Whether lists are prefered to grids</summary>
+			<summary>Whether lists are preferred to grids</summary>
 			<description>If this option is enabled, the library view will show a list instead of the
 				default grid.</description>
 		</key>

--- a/src/components/dynamic-image.ts
+++ b/src/components/dynamic-image.ts
@@ -67,7 +67,7 @@ export class DynamicImage extends Gtk.Overlay {
         "persistent-play-button": GObject.ParamSpec.boolean(
           "persistent-play-button",
           "Persistent play button",
-          "Whether the play button should alwas show persistent",
+          "Whether the play button should always show persistent",
           GObject.ParamFlags.READWRITE,
           true,
         ),

--- a/src/mpris.ts
+++ b/src/mpris.ts
@@ -531,7 +531,7 @@ export class MPRIS extends DBusInterface {
    * Seek forward in the current track
    *
    * Seek is relative to the current player position
-   * If the value passed in would mean seeking beyong the end of the track,
+   * If the value passed in would mean seeking beyond the end of the track,
    * acts like a call to next
    */
   _seek(offset_variant: GLib.Variant) {
@@ -571,7 +571,7 @@ export class MPRIS extends DBusInterface {
   /**
    * Open the URI given as an argument
    *
-   * Not impremented
+   * Not implemented
    */
   open_uri(_uri: string) {
     return;

--- a/types/ambient.d.ts
+++ b/types/ambient.d.ts
@@ -1,7 +1,7 @@
 declare function _(id: string): string;
 declare function print(args: string): void;
 declare function log(obj: object, others?: object[]): void;
-declare function log(msg: string, subsitutions?: any[]): void;
+declare function log(msg: string, substitutions?: any[]): void;
 
 declare const pkg: {
   version: string;


### PR DESCRIPTION
found via `codespell -S *.lock,*.json -L trough`