### PR TITLE
Save Scroll State

### DIFF
--- a/data/ui/components/library/history.blp
+++ b/data/ui/components/library/history.blp
@@ -6,7 +6,7 @@ template $HistoryPage : Adw.Bin {
     [top]
     Adw.HeaderBar {}
   
-    content: ScrolledWindow {
+    content: ScrolledWindow scrolled {
       hexpand: true;
       hscrollbar-policy: never;
 

--- a/data/ui/components/library/songs.blp
+++ b/data/ui/components/library/songs.blp
@@ -6,7 +6,7 @@ template $LibrarySongsPage : Adw.Bin {
     [top]
     Adw.HeaderBar {}
   
-    content: ScrolledWindow {
+    content: ScrolledWindow scrolled {
       hexpand: true;
       hscrollbar-policy: never;
 

--- a/data/ui/pages/artist-albums.blp
+++ b/data/ui/pages/artist-albums.blp
@@ -6,7 +6,7 @@ template $ArtistAlbumsPage : Adw.Bin {
     [top]
     Adw.HeaderBar {}
   
-    content: ScrolledWindow {
+    content: ScrolledWindow scrolled {
       hexpand: true;
       hscrollbar-policy: never;
 

--- a/data/ui/pages/artist.blp
+++ b/data/ui/pages/artist.blp
@@ -14,7 +14,7 @@ template $ArtistPage : Adw.Bin {
         condition ("max-width: 700sp")
       }
 
-      ScrolledWindow {
+      ScrolledWindow scrolled {
         vexpand: true;
         hexpand: true;
         hscrollbar-policy: never;

--- a/data/ui/pages/channel-playlists.blp
+++ b/data/ui/pages/channel-playlists.blp
@@ -6,7 +6,7 @@ template $ChannelPlaylistsPage : Adw.Bin {
     [top]
     Adw.HeaderBar {}
   
-    content: ScrolledWindow {
+    content: ScrolledWindow scrolled {
       hexpand: true;
       hscrollbar-policy: never;
 

--- a/data/ui/pages/channel.blp
+++ b/data/ui/pages/channel.blp
@@ -14,7 +14,7 @@ template $ChannelPage : Adw.Bin {
         condition ("max-width: 700sp")
       }
 
-      ScrolledWindow {
+      ScrolledWindow scrolled {
         vexpand: true;
         hexpand: true;
         hscrollbar-policy: never;

--- a/src/pages/album.ts
+++ b/src/pages/album.ts
@@ -231,9 +231,8 @@ export class AlbumPage extends Adw.Bin
   }
 
   restore_state(state: AlbumState) {
-    this.present({ album: state.album, track: state.track });
-
     set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
+    this.present({ album: state.album, track: state.track });
   }
 }
 

--- a/src/pages/album.ts
+++ b/src/pages/album.ts
@@ -11,8 +11,12 @@ import { AlbumHeader } from "../components/album/header.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { PlaylistItemView } from "src/components/playlist/itemview.js";
 import { PlayableContainer, PlayableList } from "src/util/playablelist.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
-interface AlbumState {
+interface AlbumState extends VScrollState {
   album: AlbumResult;
   track?: string;
 }
@@ -40,6 +44,7 @@ export class AlbumPage extends Adw.Bin
         "playlist_item_view",
         "header",
         "menu",
+        "scrolled",
       ],
     }, this);
   }
@@ -54,6 +59,7 @@ export class AlbumPage extends Adw.Bin
   private _playlist_item_view!: PlaylistItemView;
   private _header!: AlbumHeader;
   private _menu!: Gtk.MenuButton;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   track: string | null = null;
 
@@ -220,11 +226,14 @@ export class AlbumPage extends Adw.Bin
     return {
       album: this.album!,
       track: this.track ?? undefined,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: AlbumState) {
     this.present({ album: state.album, track: state.track });
+
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
   }
 }
 

--- a/src/pages/artist-albums.ts
+++ b/src/pages/artist-albums.ts
@@ -1,6 +1,7 @@
 import GObject from "gi://GObject";
 import Adw from "gi://Adw";
 import GLib from "gi://GLib";
+import Gtk from "gi://Gtk?version=4.0";
 
 import { ArtistAlbums, get_artist_albums } from "src/muse.js";
 
@@ -8,8 +9,12 @@ import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { CarouselGridView } from "src/components/carousel/view/grid";
 import { PlayableContainer } from "src/util/playablelist";
 import { MixedCardItem } from "src/components/library/mixedcard";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled";
 
-interface ArtistAlbumsState {
+interface ArtistAlbumsState extends VScrollState {
   contents: ArtistAlbums;
 }
 
@@ -21,11 +26,12 @@ export class ArtistAlbumsPage extends Adw.Bin
     GObject.registerClass({
       GTypeName: "ArtistAlbumsPage",
       Template: "resource:///com/vixalien/muzika/ui/pages/artist-albums.ui",
-      InternalChildren: ["view"],
+      InternalChildren: ["view", "scrolled"],
     }, this);
   }
 
   private _view!: CarouselGridView;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   constructor() {
     super();
@@ -88,10 +94,12 @@ export class ArtistAlbumsPage extends Adw.Bin
   get_state() {
     return {
       contents: this.results!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: ArtistAlbumsState): void {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.show_artist_albums(state.contents);
   }
 

--- a/src/pages/artist.ts
+++ b/src/pages/artist.ts
@@ -12,8 +12,12 @@ import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { PlaylistListView } from "src/components/playlist/listview.js";
 import { PlaylistItemView } from "src/components/playlist/itemview.js";
 import { PlayableContainer, PlayableList } from "src/util/playablelist.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
-interface ArtistState {
+interface ArtistState extends VScrollState {
   artist: Artist;
 }
 
@@ -33,6 +37,7 @@ export class ArtistPage extends Adw.Bin
         "more_top_songs",
         "playlist_item_view",
         "header",
+        "scrolled",
       ],
     }, this);
   }
@@ -45,6 +50,7 @@ export class ArtistPage extends Adw.Bin
   private _more_top_songs!: Gtk.Button;
   private _playlist_item_view!: PlaylistItemView;
   private _header!: ArtistHeader;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   model = new PlayableList();
 
@@ -178,10 +184,13 @@ export class ArtistPage extends Adw.Bin
   get_state(): ArtistState {
     return {
       artist: this.artist!,
+      vscroll: this._scrolled.vadjustment.value,
     };
   }
 
   restore_state(state: ArtistState) {
     this.present(state.artist);
+
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
   }
 }

--- a/src/pages/channel-playlists.ts
+++ b/src/pages/channel-playlists.ts
@@ -1,6 +1,7 @@
 import GObject from "gi://GObject";
 import Adw from "gi://Adw";
 import GLib from "gi://GLib";
+import Gtk from "gi://Gtk?version=4.0";
 
 import {
   ChannelPlaylists,
@@ -11,8 +12,12 @@ import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { CarouselGridView } from "src/components/carousel/view/grid";
 import { PlayableContainer } from "src/util/playablelist";
 import { MixedCardItem } from "src/components/library/mixedcard";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled";
 
-interface ChannelPlaylistsState {
+interface ChannelPlaylistsState extends VScrollState {
   contents: ChannelPlaylists;
 }
 
@@ -24,11 +29,12 @@ export class ChannelPlaylistsPage extends Adw.Bin
     GObject.registerClass({
       GTypeName: "ChannelPlaylistsPage",
       Template: "resource:///com/vixalien/muzika/ui/pages/channel-playlists.ui",
-      InternalChildren: ["view"],
+      InternalChildren: ["view", "scrolled"],
     }, this);
   }
 
   private _view!: CarouselGridView;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   constructor() {
     super();
@@ -91,10 +97,12 @@ export class ChannelPlaylistsPage extends Adw.Bin
   get_state() {
     return {
       contents: this.results!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: ChannelPlaylistsState): void {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.show_channel_playlists(state.contents);
   }
 

--- a/src/pages/channel-playlists.ts
+++ b/src/pages/channel-playlists.ts
@@ -3,10 +3,7 @@ import Adw from "gi://Adw";
 import GLib from "gi://GLib";
 import Gtk from "gi://Gtk?version=4.0";
 
-import {
-  ChannelPlaylists,
-  get_artist_albums as get_channel_playlists,
-} from "src/muse.js";
+import { ChannelPlaylists, get_channel_playlists } from "src/muse.js";
 
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { CarouselGridView } from "src/components/carousel/view/grid";

--- a/src/pages/channel.ts
+++ b/src/pages/channel.ts
@@ -16,8 +16,12 @@ import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { PlaylistListView } from "src/components/playlist/listview.js";
 import { PlaylistItemView } from "src/components/playlist/itemview.js";
 import { PlayableContainer, PlayableList } from "src/util/playablelist.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
-interface ChannelState {
+interface ChannelState extends VScrollState {
   channel: Channel;
 }
 
@@ -36,6 +40,7 @@ export class ChannelPage extends Adw.Bin
         "songs_on_repeat",
         "playlist_item_view",
         "header",
+        "scrolled",
       ],
     }, this);
   }
@@ -47,6 +52,7 @@ export class ChannelPage extends Adw.Bin
   private _songs_on_repeat!: Gtk.Box;
   private _playlist_item_view!: PlaylistItemView;
   private _header!: ArtistHeader;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   model = new PlayableList();
 
@@ -153,10 +159,12 @@ export class ChannelPage extends Adw.Bin
   get_state(): ChannelState {
     return {
       channel: this.channel!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: ChannelState) {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.present(state.channel);
   }
 }

--- a/src/pages/charts.ts
+++ b/src/pages/charts.ts
@@ -13,10 +13,14 @@ import { Carousel } from "../components/carousel/index.js";
 import { Loading } from "../components/loading.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { MixedCardItem } from "src/components/library/mixedcard.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 Loading;
 
-export interface ChartsPageState {
+export interface ChartsPageState extends VScrollState {
   contents: Charts;
 }
 
@@ -88,10 +92,12 @@ export class ChartsPage extends Adw.Bin
   get_state() {
     return {
       contents: this.contents!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: ChartsPageState) {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.present(state.contents);
   }
 

--- a/src/pages/explore.ts
+++ b/src/pages/explore.ts
@@ -13,10 +13,14 @@ import { Carousel } from "../components/carousel/index.js";
 import { Loading } from "../components/loading.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { MixedCardItem } from "src/components/library/mixedcard.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 Loading;
 
-export interface ExplorePageState {
+export interface ExplorePageState extends VScrollState {
   contents: ExploreContents;
 }
 
@@ -58,10 +62,12 @@ export class ExplorePage extends Adw.Bin
   get_state() {
     return {
       contents: this.contents!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: ExplorePageState) {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.present(state.contents);
   }
 

--- a/src/pages/home.ts
+++ b/src/pages/home.ts
@@ -9,11 +9,15 @@ import { get_home, Home, MixedContent } from "../muse.js";
 import { Carousel } from "../components/carousel/index.js";
 import { Loading } from "../components/loading.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 Loading;
 Paginator;
 
-export interface HomePageState {
+export interface HomePageState extends VScrollState {
   home: Home;
 }
 
@@ -65,11 +69,14 @@ export class HomePage extends Adw.Bin
   get_state() {
     return {
       home: this.home!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: HomePageState) {
     this.present(state.home);
+
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
   }
 
   clear() {

--- a/src/pages/library/base.ts
+++ b/src/pages/library/base.ts
@@ -9,6 +9,10 @@ import { LibraryView } from "../../components/library/view.js";
 import type { LibraryOrder, Order } from "libmuse/types/mixins/utils.js";
 import { MixedCardItem } from "src/components/library/mixedcard.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 export const library_orders = new Map<string, LibraryOrder>([
   [_("Recent activity"), "recent_activity"],
@@ -45,7 +49,7 @@ export interface LibraryPageOptions {
   uri: string;
 }
 
-interface LibraryState {
+interface LibraryState extends VScrollState {
   results: LibraryResults;
   order?: string;
 }
@@ -131,12 +135,15 @@ export class AbstractLibraryPage<PageOrder extends LibraryOrder | Order = Order>
 
     this.results = state.results;
     this.show_library(state.results);
+
+    set_scrolled_window_initial_vscroll(this.view.scrolled, state.vscroll);
   }
 
   get_state(): LibraryState {
     return {
       results: this.results!,
       order: this.order,
+      vscroll: this.view.scrolled.get_vadjustment().get_value(),
     };
   }
 

--- a/src/pages/library/history.ts
+++ b/src/pages/library/history.ts
@@ -6,6 +6,10 @@ import { get_history, History, PlaylistItem } from "../../muse.js";
 
 import { PlaylistItemCard } from "src/components/playlist/item.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 interface PlaylistItemWithCategory extends PlaylistItem {
   category?: string;
@@ -15,7 +19,7 @@ interface HistoryTitleOptions {
   title: string;
 }
 
-interface HistoryState {
+interface HistoryState extends VScrollState {
   results: History;
 }
 
@@ -50,11 +54,12 @@ export class HistoryPage extends Adw.Bin
       GTypeName: "HistoryPage",
       Template:
         "resource:///com/vixalien/muzika/ui/components/library/history.ui",
-      InternalChildren: ["list"],
+      InternalChildren: ["list", "scrolled"],
     }, this);
   }
 
   private _list!: Gtk.ListBox;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   results?: History;
 
@@ -106,10 +111,12 @@ export class HistoryPage extends Adw.Bin
   get_state() {
     return {
       results: this.results!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: HistoryState) {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.present(state.results);
   }
 

--- a/src/pages/library/songs.ts
+++ b/src/pages/library/songs.ts
@@ -10,6 +10,10 @@ import { Paginator } from "src/components/paginator.js";
 import { PlaylistItemCard } from "src/components/playlist/item.js";
 import type { Order } from "libmuse/types/mixins/utils.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 // make sure paginator is registered before LibrarySongsPage
 Paginator;
@@ -21,13 +25,14 @@ export class LibrarySongsPage extends Adw.Bin
       GTypeName: "LibrarySongsPage",
       Template:
         "resource:///com/vixalien/muzika/ui/components/library/songs.ui",
-      InternalChildren: ["drop_down", "paginator"],
+      InternalChildren: ["drop_down", "paginator", "scrolled"],
       Children: ["list"],
     }, this);
   }
 
   private _drop_down!: Gtk.DropDown;
   private _paginator!: Paginator;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   list!: Gtk.Box;
 
@@ -115,10 +120,13 @@ export class LibrarySongsPage extends Adw.Bin
     return {
       results: this.results!,
       order: this.order,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: LibrarySongsState): void {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
+
     if (state.order) {
       const order = order_id_to_name(state.order, alphabetical_orders);
 
@@ -163,7 +171,7 @@ interface LoadedSongs {
   order?: Order;
 }
 
-interface LibrarySongsState {
+interface LibrarySongsState extends VScrollState {
   results: LibrarySongs;
   order?: string;
 }

--- a/src/pages/mood-playlists.ts
+++ b/src/pages/mood-playlists.ts
@@ -7,10 +7,14 @@ import { get_mood_playlists, MoodPlaylists } from "../muse.js";
 import { Carousel } from "../components/carousel/index.js";
 import { Loading } from "../components/loading.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 Loading;
 
-export interface MoodPlaylistsPageState {
+export interface MoodPlaylistsPageState extends VScrollState {
   contents: MoodPlaylists;
 }
 
@@ -54,10 +58,12 @@ export class MoodPlaylistsPage extends Adw.Bin
   get_state() {
     return {
       contents: this.contents!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: MoodPlaylistsPageState) {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.present(state.contents);
   }
 

--- a/src/pages/moods.ts
+++ b/src/pages/moods.ts
@@ -7,10 +7,14 @@ import { get_mood_categories, MoodCategories } from "../muse.js";
 import { Carousel } from "../components/carousel/index.js";
 import { Loading } from "../components/loading.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 Loading;
 
-export interface MoodsPageState {
+export interface MoodsPageState extends VScrollState {
   contents: MoodCategories;
 }
 
@@ -50,10 +54,12 @@ export class MoodsPage extends Adw.Bin
   get_state() {
     return {
       contents: this.contents!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: MoodsPageState) {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.present(state.contents);
   }
 

--- a/src/pages/new-releases.ts
+++ b/src/pages/new-releases.ts
@@ -7,10 +7,14 @@ import { get_new_releases, NewReleases } from "../muse.js";
 import { Carousel } from "../components/carousel/index.js";
 import { Loading } from "../components/loading.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 Loading;
 
-export interface NewReleasesPageState {
+export interface NewReleasesPageState extends VScrollState {
   contents: NewReleases;
 }
 
@@ -54,10 +58,12 @@ export class NewReleasesPage extends Adw.Bin
   get_state() {
     return {
       contents: this.contents!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: NewReleasesPageState) {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.present(state.contents);
   }
 

--- a/src/pages/playlist.ts
+++ b/src/pages/playlist.ts
@@ -28,8 +28,12 @@ import {
 } from "src/components/playlist/edit.js";
 import { Window } from "src/window.js";
 import { PlayableContainer, PlayableList } from "src/util/playablelist.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
-interface PlaylistState {
+interface PlaylistState extends VScrollState {
   playlist: Playlist;
 }
 
@@ -411,10 +415,13 @@ export class PlaylistPage extends Adw.Bin
           .map((container) => (container as PlayableContainer).object)
           .filter((item) => item != null) as PlaylistItem[],
       },
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: PlaylistState) {
     this.present(state.playlist);
+
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
   }
 }

--- a/src/pages/search.ts
+++ b/src/pages/search.ts
@@ -18,10 +18,14 @@ import { Paginator } from "../components/paginator.js";
 import { InlineTabSwitcher, Tab } from "../components/inline-tab-switcher.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { escape_label } from "src/util/text.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 const vprintf = imports.format.vprintf;
 
-interface SearchState {
+interface SearchState extends VScrollState {
   results: SearchResults;
   args: Parameters<typeof search>;
 }
@@ -342,11 +346,14 @@ export class SearchPage extends Adw.Bin
     return {
       results: this.results!,
       args: this.args,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: SearchState) {
     this.present(state);
+
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
   }
 }
 

--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -376,7 +376,7 @@ export class MuzikaMediaStream extends Gtk.MediaStream {
     this._error = error;
     this.notify("error");
 
-    console.error("error during playback", error.message, error.toString());
+    console.error("error during playback", error.toString());
 
     // TODO: cancel pending seeks
     this._play.stop();

--- a/src/util/scrolled.ts
+++ b/src/util/scrolled.ts
@@ -1,0 +1,26 @@
+import Gtk from "gi://Gtk?version=4.0";
+
+export function set_scrolled_window_initial_vscroll(
+  scrolled_window: Gtk.ScrolledWindow,
+  vscroll: number,
+) {
+  if (vscroll === 0) {
+    return;
+  }
+
+  let signal_id: number | null = scrolled_window.vadjustment.connect(
+    "notify::upper",
+    () => {
+      scrolled_window.vadjustment.value = vscroll;
+
+      if (signal_id !== null) {
+        scrolled_window.vadjustment.disconnect(signal_id);
+        signal_id = null;
+      }
+    },
+  );
+}
+
+export interface VScrollState {
+  vscroll: number;
+}

--- a/src/util/scrolled.ts
+++ b/src/util/scrolled.ts
@@ -1,4 +1,5 @@
 import Gtk from "gi://Gtk?version=4.0";
+import GLib from "gi://GLib";
 
 export function set_scrolled_window_initial_vscroll(
   scrolled_window: Gtk.ScrolledWindow,
@@ -11,12 +12,16 @@ export function set_scrolled_window_initial_vscroll(
   let signal_id: number | null = scrolled_window.vadjustment.connect(
     "notify::upper",
     () => {
-      scrolled_window.vadjustment.value = vscroll;
+      GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+        scrolled_window.vadjustment.value = vscroll;
 
-      if (signal_id !== null) {
-        scrolled_window.vadjustment.disconnect(signal_id);
-        signal_id = null;
-      }
+        if (signal_id !== null) {
+          scrolled_window.vadjustment.disconnect(signal_id);
+          signal_id = null;
+        }
+
+        return GLib.SOURCE_REMOVE;
+      });
     },
   );
 }


### PR DESCRIPTION
Supported pages

- [x] Home
- [x] Playlist
- [x] Album
- [x] Artist
- [x] Search Results
- [x] Library
- [x] Library Playlists
- [x] Library Albums
- [x] Library Artists
- [x] Library Subscriptions
- [x] Library Songs
- [x] History
- [x] Artist Albums
- [x] Channel
- [x] Channel Playlists
- [x] Explore
- [x] Charts
- [x] Moods and genres
- [x] Mood
- [x] New Releases

#### Checking if all pages work correctly

- [ ] Home (!)
- [x] Playlist
- [x] Album
- [x] Artist
- [x] Search Results
- [ ] Library (!)
- [ ] Library Playlists (!)
- [ ] Library Albums (!)
- [ ] Library Artists (!)
- [ ] Library Subscriptions (!)
- [x] Library Songs
- [ ] History (!)
- [x] Artist Albums
- [x] Channel
- [x] Channel Playlists
- [ ] Explore (!)
- [x] Charts
- [x] Moods and genres
- [x] Mood
- [x] New Releases

Items with `(!)` for some reason save the scroll state well, but won't restore it: they restore the state but then they immediately scroll to the top.

fix #49 