### PR TITLE
Save Scroll State (2)

### DIFF
--- a/data/com.vixalien.muzika.appdata.xml.in.in
+++ b/data/com.vixalien.muzika.appdata.xml.in.in
@@ -2,7 +2,7 @@
 <component type="desktop-application">
 	<id>@app-id@.desktop</id>
 	<metadata_license>CC0-1.0</metadata_license>
-	<project_license>GPL-3.0+</project_license>
+	<project_license>GPL-3.0</project_license>
 	<name>Muzika</name>
 	<summary>Elegant music streaming application</summary>
 	<description>
@@ -25,6 +25,10 @@
 				https://raw.githubusercontent.com/vixalien/muzika/main/data/resources/screenshots/home.png</image>
 		</screenshot>
 	</screenshots>
+	<releases>
+    <release version="0.1.0" date="2023-09-22">
+    </release>
+  </releases>
 	<launchable type="desktop-id">@app-id@.desktop</launchable>
 	<url type="homepage">https://github.com/vixalien/muzika</url>
 	<url type="bugtracker">https://github.com/vixalien/muzika/issues</url>

--- a/data/com.vixalien.muzika.data.gresource.xml
+++ b/data/com.vixalien.muzika.data.gresource.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/com/vixalien/muzika">
+    <!-- appdata -->
+    <file preprocess="xml-stripblanks">com.vixalien.muzika.appdata.xml</file>
     <!-- style -->
     <file>style.css</file>
     <!-- components -->

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,9 +1,9 @@
 desktop_file = i18n.merge_file(
-        input: 'com.vixalien.muzika.desktop.in',
-       output: 'com.vixalien.muzika.desktop',
-         type: 'desktop',
-       po_dir: '../po',
-      install: true,
+  input: 'com.vixalien.muzika.desktop.in',
+  output: 'com.vixalien.muzika.desktop',
+  type: 'desktop',
+  po_dir: '../po',
+  install: true,
   install_dir: join_paths(get_option('datadir'), 'applications')
 )
 
@@ -16,15 +16,15 @@ appdata_conf = configuration_data()
 appdata_conf.set('app-id', 'com.vixalien.muzika')
 
 appstream_file = i18n.merge_file(
-        input: configure_file(
-                  input: 'com.vixalien.muzika.appdata.xml.in.in',
-                 output: 'com.vixalien.muzika.appdata.xml.in',
-          configuration: appdata_conf
-        ),
-       output: 'com.vixalien.muzika.appdata.xml',
-       po_dir: '../po',
-      install: true,
-  install_dir: join_paths(get_option('datadir'), 'appdata')
+  input: configure_file(
+    input: 'com.vixalien.muzika.appdata.xml.in.in',
+    output: 'com.vixalien.muzika.appdata.xml.in',
+    configuration: appdata_conf
+  ),
+  output: 'com.vixalien.muzika.appdata.xml',
+  po_dir: '../po',
+  install: true,
+  install_dir: join_paths(get_option('datadir'), 'appdata'),
 )
 
 appstream_util = find_program('appstream-util', required: false)
@@ -67,7 +67,7 @@ data_res = gnome.compile_resources(
   gresource_bundle: true,
   install: true,
   install_dir: pkgdatadir,
-  dependencies: blueprints,
+  dependencies: [blueprints, appstream_file],
 )
 
 subdir('icons')

--- a/data/ui/components/library/history.blp
+++ b/data/ui/components/library/history.blp
@@ -18,7 +18,7 @@ template $HistoryPage : Adw.Bin {
         }
       }
       
-      ScrolledWindow {
+      ScrolledWindow scrolled {
         hexpand: true;
         hscrollbar-policy: never;
 

--- a/data/ui/components/library/songs.blp
+++ b/data/ui/components/library/songs.blp
@@ -18,7 +18,7 @@ template $LibrarySongsPage : Adw.Bin {
         }
       }
       
-      ScrolledWindow {
+      ScrolledWindow scrolled {
         hexpand: true;
         hscrollbar-policy: never;
 

--- a/data/ui/pages/artist-albums.blp
+++ b/data/ui/pages/artist-albums.blp
@@ -6,7 +6,7 @@ template $ArtistAlbumsPage : Adw.Bin {
     [top]
     Adw.HeaderBar {}
   
-    content: ScrolledWindow {
+    content: ScrolledWindow scrolled {
       hexpand: true;
       hscrollbar-policy: never;
 

--- a/data/ui/pages/artist.blp
+++ b/data/ui/pages/artist.blp
@@ -24,7 +24,7 @@ template $ArtistPage : Adw.Bin {
         }
       }
 
-      ScrolledWindow {
+      ScrolledWindow scrolled {
         vexpand: true;
         hexpand: true;
         hscrollbar-policy: never;

--- a/data/ui/pages/channel-playlists.blp
+++ b/data/ui/pages/channel-playlists.blp
@@ -6,7 +6,7 @@ template $ChannelPlaylistsPage : Adw.Bin {
     [top]
     Adw.HeaderBar {}
   
-    content: ScrolledWindow {
+    content: ScrolledWindow scrolled {
       hexpand: true;
       hscrollbar-policy: never;
 

--- a/data/ui/pages/channel.blp
+++ b/data/ui/pages/channel.blp
@@ -24,7 +24,7 @@ template $ChannelPage : Adw.Bin {
         }
       }
 
-      ScrolledWindow {
+      ScrolledWindow scrolled {
         vexpand: true;
         hexpand: true;
         hscrollbar-policy: never;

--- a/data/ui/pages/search.blp
+++ b/data/ui/pages/search.blp
@@ -14,7 +14,7 @@ template $SearchPage : Adw.Bin {
         condition ("max-width: 800sp")
       }
       
-      ScrolledWindow {
+      ScrolledWindow scrolled {
         vexpand: true;
         hscrollbar-policy: never;
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -72,22 +72,17 @@ export class Application extends Adw.Application {
 
     const show_about_action = new Gio.SimpleAction({ name: "about" });
     show_about_action.connect("activate", () => {
-      const aboutWindow = new Adw.AboutWindow({
-        transient_for: this.active_window,
-        application_name: "Muzika",
-        application_icon: "com.vixalien.muzika",
-        developer_name: "Angelo Verlain",
-        version: pkg.version,
-        developers: [
-          "Angelo Verlain <hey@vixalien.com>",
-          "Christopher Davis <christopherdavis@gnome.org>",
-          "Kian-Meng Ang <kianmeng@cpan.org>",
-        ],
-        copyright: "© 2023 Angelo Verlain",
-        license_type: Gtk.License.GPL_3_0,
-        debug_info: this.get_debug_info(),
-        website: "https://github.com/vixalien/muzika",
-      });
+      const aboutWindow = Adw.AboutWindow.new_from_appdata(
+        "/com/vixalien/muzika/com.vixalien.muzika.appdata.xml",
+        "0.1.0",
+      );
+
+      aboutWindow.set_developers([
+        "Angelo Verlain <hey@vixalien.com>",
+        "Christopher Davis <christopherdavis@gnome.org>",
+        "Kian-Meng Ang <kianmeng@cpan.org>",
+      ]);
+      aboutWindow.set_debug_info(this.get_debug_info());
 
       aboutWindow.present();
     });

--- a/src/components/dynamic-image.ts
+++ b/src/components/dynamic-image.ts
@@ -218,9 +218,9 @@ export class DynamicImage extends Gtk.Overlay {
         break;
       }
       case DynamicImageStorageType.VIDEO_THUMBNAIL: {
-        const image = child as FixedRatioThumbnail;
-        image.min_width = (16 / 9) * this.size;
-        image.min_height = this.size;
+        const picture = child as Gtk.Picture;
+        picture.width_request = (16 / 9) * this.size;
+        picture.height_request = this.size;
         this.update_image_class();
         break;
       }
@@ -285,11 +285,10 @@ export class DynamicImage extends Gtk.Overlay {
         (child as FixedRatioThumbnail).can_expand = this.can_expand;
         break;
       case DynamicImageStorageType.VIDEO_THUMBNAIL:
-        child = new FixedRatioThumbnail({
+        child = new Gtk.Picture({
           overflow: Gtk.Overflow.HIDDEN,
+          content_fit: Gtk.ContentFit.FILL,
         });
-        (child as FixedRatioThumbnail).aspect_ratio = 16 / 9;
-        (child as FixedRatioThumbnail).can_expand = this.can_expand;
         break;
       case DynamicImageStorageType.AVATAR:
         this._action.locked = true;

--- a/src/components/player/lyrics.ts
+++ b/src/components/player/lyrics.ts
@@ -185,7 +185,7 @@ export class LyricsView extends Gtk.Stack {
     const [success, rect] = row.compute_bounds(this._timed_listbox);
 
     if (success) {
-      const scroll_to = rect.get_y() - 60;
+      const scroll_to = rect.get_y() - 180;
 
       // don't scroll if the scroll value is near the target (in one direction)
       if (

--- a/src/pages/album.ts
+++ b/src/pages/album.ts
@@ -238,9 +238,8 @@ export class AlbumPage extends Adw.Bin
   }
 
   restore_state(state: AlbumState) {
-    this.present({ album: state.album, track: state.track });
-
     set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
+    this.present({ album: state.album, track: state.track });
   }
 }
 

--- a/src/pages/album.ts
+++ b/src/pages/album.ts
@@ -11,8 +11,12 @@ import { AlbumHeader } from "../components/album/header.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { PlaylistItemView } from "src/components/playlist/itemview.js";
 import { PlayableContainer, PlayableList } from "src/util/playablelist.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
-interface AlbumState {
+interface AlbumState extends VScrollState {
   album: AlbumResult;
   track?: string;
 }
@@ -39,6 +43,7 @@ export class AlbumPage extends Adw.Bin
         "playlist_item_view",
         "header",
         "menu",
+        "scrolled",
       ],
     }, this);
   }
@@ -52,6 +57,7 @@ export class AlbumPage extends Adw.Bin
   private _playlist_item_view!: PlaylistItemView;
   private _header!: AlbumHeader;
   private _menu!: Gtk.MenuButton;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   track: string | null = null;
 
@@ -227,11 +233,14 @@ export class AlbumPage extends Adw.Bin
     return {
       album: this.album!,
       track: this.track ?? undefined,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: AlbumState) {
     this.present({ album: state.album, track: state.track });
+
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
   }
 }
 

--- a/src/pages/artist-albums.ts
+++ b/src/pages/artist-albums.ts
@@ -1,6 +1,7 @@
 import GObject from "gi://GObject";
 import Adw from "gi://Adw";
 import GLib from "gi://GLib";
+import Gtk from "gi://Gtk?version=4.0";
 
 import { ArtistAlbums, get_artist_albums } from "src/muse.js";
 
@@ -8,8 +9,12 @@ import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { CarouselGridView } from "src/components/carousel/view/grid";
 import { PlayableContainer } from "src/util/playablelist";
 import { MixedCardItem } from "src/components/library/mixedcard";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled";
 
-interface ArtistAlbumsState {
+interface ArtistAlbumsState extends VScrollState {
   contents: ArtistAlbums;
 }
 
@@ -21,11 +26,12 @@ export class ArtistAlbumsPage extends Adw.Bin
     GObject.registerClass({
       GTypeName: "ArtistAlbumsPage",
       Template: "resource:///com/vixalien/muzika/ui/pages/artist-albums.ui",
-      InternalChildren: ["view"],
+      InternalChildren: ["view", "scrolled"],
     }, this);
   }
 
   private _view!: CarouselGridView;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   constructor() {
     super();
@@ -88,10 +94,12 @@ export class ArtistAlbumsPage extends Adw.Bin
   get_state() {
     return {
       contents: this.results!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: ArtistAlbumsState): void {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.show_artist_albums(state.contents);
   }
 

--- a/src/pages/artist.ts
+++ b/src/pages/artist.ts
@@ -13,8 +13,12 @@ import { PlaylistListView } from "src/components/playlist/listview.js";
 import { PlaylistItemView } from "src/components/playlist/itemview.js";
 import { PlayableContainer, PlayableList } from "src/util/playablelist.js";
 import { get_square_thumbnails } from "src/components/webimage.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
-interface ArtistState {
+interface ArtistState extends VScrollState {
   artist: Artist;
 }
 
@@ -34,6 +38,7 @@ export class ArtistPage extends Adw.Bin
         "header",
         "carousels",
         "menu",
+        "scrolled",
       ],
     }, this);
   }
@@ -46,6 +51,7 @@ export class ArtistPage extends Adw.Bin
   private _header!: ArtistHeader;
   private _carousels!: Gtk.Box;
   private _menu!: Gtk.MenuButton;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   model = new PlayableList();
 
@@ -195,10 +201,13 @@ export class ArtistPage extends Adw.Bin
   get_state(): ArtistState {
     return {
       artist: this.artist!,
+      vscroll: this._scrolled.vadjustment.value,
     };
   }
 
   restore_state(state: ArtistState) {
     this.present(state.artist);
+
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
   }
 }

--- a/src/pages/channel-playlists.ts
+++ b/src/pages/channel-playlists.ts
@@ -1,6 +1,7 @@
 import GObject from "gi://GObject";
 import Adw from "gi://Adw";
 import GLib from "gi://GLib";
+import Gtk from "gi://Gtk?version=4.0";
 
 import { ChannelPlaylists, get_channel_playlists } from "src/muse.js";
 
@@ -8,8 +9,12 @@ import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { CarouselGridView } from "src/components/carousel/view/grid";
 import { PlayableContainer } from "src/util/playablelist";
 import { MixedCardItem } from "src/components/library/mixedcard";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled";
 
-interface ChannelPlaylistsState {
+interface ChannelPlaylistsState extends VScrollState {
   contents: ChannelPlaylists;
 }
 
@@ -21,11 +26,12 @@ export class ChannelPlaylistsPage extends Adw.Bin
     GObject.registerClass({
       GTypeName: "ChannelPlaylistsPage",
       Template: "resource:///com/vixalien/muzika/ui/pages/channel-playlists.ui",
-      InternalChildren: ["view"],
+      InternalChildren: ["view", "scrolled"],
     }, this);
   }
 
   private _view!: CarouselGridView;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   constructor() {
     super();
@@ -88,10 +94,12 @@ export class ChannelPlaylistsPage extends Adw.Bin
   get_state() {
     return {
       contents: this.results!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: ChannelPlaylistsState): void {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.show_channel_playlists(state.contents);
   }
 

--- a/src/pages/channel.ts
+++ b/src/pages/channel.ts
@@ -17,8 +17,12 @@ import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { PlaylistListView } from "src/components/playlist/listview.js";
 import { PlaylistItemView } from "src/components/playlist/itemview.js";
 import { PlayableContainer, PlayableList } from "src/util/playablelist.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
-interface ChannelState {
+interface ChannelState extends VScrollState {
   channel: Channel;
 }
 
@@ -37,6 +41,7 @@ export class ChannelPage extends Adw.Bin
         "header",
         "carousels",
         "menu",
+        "scrolled",
       ],
     }, this);
   }
@@ -48,6 +53,7 @@ export class ChannelPage extends Adw.Bin
   private _header!: ArtistHeader;
   private _carousels!: Gtk.Box;
   private _menu!: Gtk.MenuButton;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   model = new PlayableList();
 
@@ -163,10 +169,12 @@ export class ChannelPage extends Adw.Bin
   get_state(): ChannelState {
     return {
       channel: this.channel!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: ChannelState) {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.present(state.channel);
   }
 }

--- a/src/pages/charts.ts
+++ b/src/pages/charts.ts
@@ -13,10 +13,14 @@ import { Carousel } from "../components/carousel/index.js";
 import { Loading } from "../components/loading.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { MixedCardItem } from "src/components/library/mixedcard.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 Loading;
 
-export interface ChartsPageState {
+export interface ChartsPageState extends VScrollState {
   contents: Charts;
 }
 
@@ -88,10 +92,12 @@ export class ChartsPage extends Adw.Bin
   get_state() {
     return {
       contents: this.contents!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: ChartsPageState) {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.present(state.contents);
   }
 

--- a/src/pages/explore.ts
+++ b/src/pages/explore.ts
@@ -13,10 +13,14 @@ import { Carousel } from "../components/carousel/index.js";
 import { Loading } from "../components/loading.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { MixedCardItem } from "src/components/library/mixedcard.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 Loading;
 
-export interface ExplorePageState {
+export interface ExplorePageState extends VScrollState {
   contents: ExploreContents;
 }
 
@@ -54,10 +58,12 @@ export class ExplorePage extends Adw.Bin
   get_state() {
     return {
       contents: this.contents!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: ExplorePageState) {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.present(state.contents);
   }
 

--- a/src/pages/home.ts
+++ b/src/pages/home.ts
@@ -9,11 +9,15 @@ import { get_home, Home, MixedContent } from "../muse.js";
 import { Carousel } from "../components/carousel/index.js";
 import { Loading } from "../components/loading.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 Loading;
 Paginator;
 
-export interface HomePageState {
+export interface HomePageState extends VScrollState {
   home: Home;
 }
 
@@ -66,11 +70,14 @@ export class HomePage extends Adw.Bin
   get_state() {
     return {
       home: this.home!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: HomePageState) {
     this.present(state.home);
+
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
   }
 
   clear() {

--- a/src/pages/library/base.ts
+++ b/src/pages/library/base.ts
@@ -9,6 +9,10 @@ import { LibraryView } from "../../components/library/view.js";
 import type { LibraryOrder, Order } from "libmuse/types/mixins/utils.js";
 import { MixedCardItem } from "src/components/library/mixedcard.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 export const library_orders = new Map<string, LibraryOrder>([
   [_("Recent activity"), "recent_activity"],
@@ -45,7 +49,7 @@ export interface LibraryPageOptions {
   uri: string;
 }
 
-interface LibraryState {
+interface LibraryState extends VScrollState {
   results: LibraryResults;
   order?: string;
 }
@@ -131,12 +135,15 @@ export class AbstractLibraryPage<PageOrder extends LibraryOrder | Order = Order>
 
     this.results = state.results;
     this.show_library(state.results);
+
+    set_scrolled_window_initial_vscroll(this.view.scrolled, state.vscroll);
   }
 
   get_state(): LibraryState {
     return {
       results: this.results!,
       order: this.order,
+      vscroll: this.view.scrolled.get_vadjustment().get_value(),
     };
   }
 

--- a/src/pages/library/history.ts
+++ b/src/pages/library/history.ts
@@ -10,12 +10,16 @@ import {
   SectionedPlayableContainer,
   SectionedPlayableList,
 } from "src/util/playablelist.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 interface HistoryTitleOptions {
   title?: string;
 }
 
-interface HistoryState {
+interface HistoryState extends VScrollState {
   results: History;
 }
 
@@ -65,11 +69,12 @@ export class HistoryPage extends Adw.Bin
       GTypeName: "HistoryPage",
       Template:
         "resource:///com/vixalien/muzika/ui/components/library/history.ui",
-      InternalChildren: ["item_view"],
+      InternalChildren: ["item_view", "scrolled"],
     }, this);
   }
 
   private _item_view!: PlaylistItemView;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   results?: History;
 
@@ -139,10 +144,12 @@ export class HistoryPage extends Adw.Bin
   get_state() {
     return {
       results: this.results!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: HistoryState) {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.present(state.results);
   }
 

--- a/src/pages/library/songs.ts
+++ b/src/pages/library/songs.ts
@@ -11,6 +11,10 @@ import type { Order } from "libmuse/types/mixins/utils.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { PlayableContainer, PlayableList } from "src/util/playablelist.js";
 import { PlaylistItemView } from "src/components/playlist/itemview.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 // make sure paginator is registered before LibrarySongsPage
 Paginator;
@@ -22,13 +26,14 @@ export class LibrarySongsPage extends Adw.Bin
       GTypeName: "LibrarySongsPage",
       Template:
         "resource:///com/vixalien/muzika/ui/components/library/songs.ui",
-      InternalChildren: ["item_view", "drop_down", "paginator"],
+      InternalChildren: ["item_view", "drop_down", "paginator", "scrolled"],
     }, this);
   }
 
   private _drop_down!: Gtk.DropDown;
   private _paginator!: Paginator;
   private _item_view!: PlaylistItemView;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   private items = new PlayableList();
 
@@ -111,10 +116,13 @@ export class LibrarySongsPage extends Adw.Bin
     return {
       results: this.results!,
       order: this.order,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: LibrarySongsState): void {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
+
     if (state.order) {
       const order = order_id_to_name(state.order, alphabetical_orders);
 
@@ -159,7 +167,7 @@ interface LoadedSongs {
   order?: Order;
 }
 
-interface LibrarySongsState {
+interface LibrarySongsState extends VScrollState {
   results: LibrarySongs;
   order?: string;
 }

--- a/src/pages/mood-playlists.ts
+++ b/src/pages/mood-playlists.ts
@@ -7,10 +7,14 @@ import { get_mood_playlists, MoodPlaylists } from "../muse.js";
 import { Carousel } from "../components/carousel/index.js";
 import { Loading } from "../components/loading.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 Loading;
 
-export interface MoodPlaylistsPageState {
+export interface MoodPlaylistsPageState extends VScrollState {
   contents: MoodPlaylists;
 }
 
@@ -50,10 +54,12 @@ export class MoodPlaylistsPage extends Adw.Bin
   get_state() {
     return {
       contents: this.contents!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: MoodPlaylistsPageState) {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.present(state.contents);
   }
 

--- a/src/pages/moods.ts
+++ b/src/pages/moods.ts
@@ -7,10 +7,14 @@ import { get_mood_categories, MoodCategories } from "../muse.js";
 import { Carousel } from "../components/carousel/index.js";
 import { Loading } from "../components/loading.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 Loading;
 
-export interface MoodsPageState {
+export interface MoodsPageState extends VScrollState {
   contents: MoodCategories;
 }
 
@@ -46,10 +50,12 @@ export class MoodsPage extends Adw.Bin
   get_state() {
     return {
       contents: this.contents!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: MoodsPageState) {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.present(state.contents);
   }
 

--- a/src/pages/new-releases.ts
+++ b/src/pages/new-releases.ts
@@ -7,10 +7,14 @@ import { get_new_releases, NewReleases } from "../muse.js";
 import { Carousel } from "../components/carousel/index.js";
 import { Loading } from "../components/loading.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 Loading;
 
-export interface NewReleasesPageState {
+export interface NewReleasesPageState extends VScrollState {
   contents: NewReleases;
 }
 
@@ -50,10 +54,12 @@ export class NewReleasesPage extends Adw.Bin
   get_state() {
     return {
       contents: this.contents!,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: NewReleasesPageState) {
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
     this.present(state.contents);
   }
 

--- a/src/pages/playlist.ts
+++ b/src/pages/playlist.ts
@@ -36,8 +36,12 @@ import { Window } from "src/window.js";
 import { PlayableContainer, PlayableList } from "src/util/playablelist.js";
 import { AddActionEntries } from "src/util/action.js";
 import { generate_menu } from "src/util/menu.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
-interface PlaylistState {
+interface PlaylistState extends VScrollState {
   playlist: Playlist;
 }
 
@@ -562,10 +566,13 @@ export class PlaylistPage extends Adw.Bin
           .map((container) => (container as PlayableContainer).object)
           .filter((item) => item != null) as PlaylistItem[],
       },
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: PlaylistState) {
     this.present(state.playlist);
+
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
   }
 }

--- a/src/pages/search.ts
+++ b/src/pages/search.ts
@@ -18,10 +18,14 @@ import { Paginator } from "../components/paginator.js";
 import { InlineTabSwitcher, Tab } from "../components/inline-tab-switcher.js";
 import { EndpointContext, MuzikaComponent } from "src/navigation.js";
 import { escape_label } from "src/util/text.js";
+import {
+  set_scrolled_window_initial_vscroll,
+  VScrollState,
+} from "src/util/scrolled.js";
 
 const vprintf = imports.format.vprintf;
 
-interface SearchState {
+interface SearchState extends VScrollState {
   results: SearchResults;
   args: Parameters<typeof search>;
 }
@@ -329,11 +333,14 @@ export class SearchPage extends Adw.Bin
     return {
       results: this.results!,
       args: this.args,
+      vscroll: this._scrolled.get_vadjustment().get_value(),
     };
   }
 
   restore_state(state: SearchState) {
     this.present(state);
+
+    set_scrolled_window_initial_vscroll(this._scrolled, state.vscroll);
   }
 }
 

--- a/src/pages/search.ts
+++ b/src/pages/search.ts
@@ -48,6 +48,7 @@ export class SearchPage extends Adw.Bin
         "details",
         "breakpoint",
         "paginator",
+        "scrolled",
       ],
     }, this);
   }
@@ -58,6 +59,7 @@ export class SearchPage extends Adw.Bin
   private _details!: Gtk.Box;
   private _breakpoint!: Adw.Breakpoint;
   private _paginator!: Paginator;
+  private _scrolled!: Gtk.ScrolledWindow;
 
   results?: SearchResults;
   args: Parameters<typeof search> = [""];

--- a/src/util/scrolled.ts
+++ b/src/util/scrolled.ts
@@ -1,0 +1,26 @@
+import Gtk from "gi://Gtk?version=4.0";
+
+export function set_scrolled_window_initial_vscroll(
+  scrolled_window: Gtk.ScrolledWindow,
+  vscroll: number,
+) {
+  if (vscroll === 0) {
+    return;
+  }
+
+  let signal_id: number | null = scrolled_window.vadjustment.connect(
+    "notify::upper",
+    () => {
+      scrolled_window.vadjustment.value = vscroll;
+
+      if (signal_id !== null) {
+        scrolled_window.vadjustment.disconnect(signal_id);
+        signal_id = null;
+      }
+    },
+  );
+}
+
+export interface VScrollState {
+  vscroll: number;
+}

--- a/src/util/scrolled.ts
+++ b/src/util/scrolled.ts
@@ -1,4 +1,5 @@
 import Gtk from "gi://Gtk?version=4.0";
+import GLib from "gi://GLib";
 
 export function set_scrolled_window_initial_vscroll(
   scrolled_window: Gtk.ScrolledWindow,
@@ -11,12 +12,16 @@ export function set_scrolled_window_initial_vscroll(
   let signal_id: number | null = scrolled_window.vadjustment.connect(
     "notify::upper",
     () => {
-      scrolled_window.vadjustment.value = vscroll;
+      GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+        scrolled_window.vadjustment.value = vscroll;
 
-      if (signal_id !== null) {
-        scrolled_window.vadjustment.disconnect(signal_id);
-        signal_id = null;
-      }
+        if (signal_id !== null) {
+          scrolled_window.vadjustment.disconnect(signal_id);
+          signal_id = null;
+        }
+
+        return GLib.SOURCE_REMOVE;
+      });
     },
   );
 }


### PR DESCRIPTION
Supported pages

- [x] Home
- [x] Playlist
- [x] Album
- [x] Artist
- [x] Search Results
- [x] Library
- [x] Library Playlists
- [x] Library Albums
- [x] Library Artists
- [x] Library Subscriptions
- [x] Library Songs
- [x] History
- [x] Artist Albums
- [x] Channel
- [x] Channel Playlists
- [x] Explore
- [x] Charts
- [x] Moods and genres
- [x] Mood
- [x] New Releases

#### Checking if all pages work correctly

- [ ] Home (!)
- [x] Playlist
- [x] Album
- [x] Artist
- [x] Search Results
- [ ] Library (!)
- [ ] Library Playlists (!)
- [ ] Library Albums (!)
- [ ] Library Artists (!)
- [ ] Library Subscriptions (!)
- [x] Library Songs
- [ ] History (!)
- [x] Artist Albums
- [x] Channel
- [x] Channel Playlists
- [ ] Explore (!)
- [x] Charts
- [x] Moods and genres
- [x] Mood
- [x] New Releases

Items with `(!)` for some reason save the scroll state well, but won't restore it: they restore the state but then they immediately scroll to the top.

fix #49 