### PR TITLE
Get Server Side Translations

### DIFF
--- a/build-aux/flatpak/modules/yarn-deps-sources.json
+++ b/build-aux/flatpak/modules/yarn-deps-sources.json
@@ -867,9 +867,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.yarnpkg.com/libmuse/-/libmuse-0.0.90.tgz#84054e89cc7f5e6ddf8caba2174486fb5087ded6",
-        "sha512": "04fe9f457b728f9b6188cac77bd90bb34e4a595506d74f20fd063d5061c5aa18eb9d8337065c25d3ffafe3d42aa27c5e6282bf7eecd1fd6beed930a6940b47b4",
-        "dest-filename": "libmuse-0.0.90.tgz",
+        "url": "https://registry.yarnpkg.com/libmuse/-/libmuse-0.0.91.tgz#0b268b320eee1db0ae9307d3371b538fadfc6aa7",
+        "sha512": "91b605980bc4f0b0c3b9fa93fe1a9bc270091c5c91710753068a4f740244b95a3e3e7591a7d521cc23e0d3e0bab005237dcb914287430d5830f8a8c85065ae03",
+        "dest-filename": "libmuse-0.0.91.tgz",
         "dest": "flatpak-node/yarn-mirror"
     },
     {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "@lemaik/qrcode-svg": "^1.2.0",
-    "libmuse": "^0.0.90",
+    "libmuse": "^0.0.91",
     "lodash-es": "^4.17.21",
     "path-to-regexp": "^6.2.1",
     "typescript": "^5.3.3",

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -55,4 +55,5 @@ src/pages/playlist.ts
 src/pages/search.ts
 src/player/index.ts
 src/player/queue.ts
+src/util/language.ts
 src/window.ts

--- a/src/application.ts
+++ b/src/application.ts
@@ -11,6 +11,7 @@ import { MuzikaPlayer } from "./player/index.js";
 import { MPRIS } from "./mpris.js";
 import { get_option } from "src/muse";
 import { MuzikaPreferencesDialog } from "./pages/preferences.js";
+import { get_default_muse_lang, get_language_string, set_muse_lang } from "./util/language.js";
 
 export const Settings = new Gio.Settings({ schema: pkg.name });
 
@@ -67,6 +68,8 @@ export class Application extends Adw.Application {
 
     this.set_argv(argv);
 
+    set_muse_lang();
+
     this.init_actions();
 
     const show_about_action = new Gio.SimpleAction({ name: "about" });
@@ -111,6 +114,7 @@ export class Application extends Adw.Application {
         version: pkg.version,
         uri: this.window?.navigator.current_uri,
         logged_in: get_option("auth").has_token(),
+        language: get_language_string(get_option("language")),
       },
       null,
       2,

--- a/src/util/language.ts
+++ b/src/util/language.ts
@@ -1,0 +1,52 @@
+import Pango from "gi://Pango";
+import { set_option } from "libmuse";
+import locales from "libmuse/locales/locales";
+
+function get_muse_lang(language: string) {
+  for (const lang of locales.languages) {
+    if (lang.value.toLowerCase() === language.toLowerCase()) return lang;
+  }
+
+  // do a second pass to get match "en" instead of "en-US" and similar
+  for (const lang of locales.languages) {
+    if (lang.value.toLowerCase() === language.toLowerCase().split("-")[0]) {
+      return lang;
+    }
+  }
+
+  return null;
+}
+
+export function get_default_muse_lang() {
+  const default_lang = get_muse_lang(Pango.Language.get_default().to_string());
+
+  if (default_lang) return default_lang;
+
+  for (const language of Pango.Language.get_preferred() || []) {
+    const muse_lang = get_muse_lang(language.to_string());
+
+    if (muse_lang) return muse_lang;
+  }
+
+  return null;
+}
+
+export function set_muse_lang() {
+  const lang = get_default_muse_lang();
+
+  if (lang) {
+    set_option("language", lang.value);
+  }
+}
+
+export function get_language_string(value: string) {
+  const lang = locales.languages.find((lang) => {
+    return lang.value === value;
+  });
+
+  if (lang) {
+    return `${lang.name} - ${lang.value}`;
+  }
+
+  return _("Invalid language selected");
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
+    "module": "ESNext",
     "lib": [
       "ESNext",
       "DOM"
@@ -10,14 +10,14 @@
     "checkJs": true,
     "outDir": "_build",
     "strict": true,
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "baseUrl": ".",
     "paths": {
       "*": [
         "*",
         "types/*",
         "gi-types/*"
-      ]
+      ],
     },
     "typeRoots": [
       "gi-types"

--- a/yarn.lock
+++ b/yarn.lock
@@ -819,10 +819,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-libmuse@^0.0.90:
-  version "0.0.90"
-  resolved "https://registry.yarnpkg.com/libmuse/-/libmuse-0.0.90.tgz#84054e89cc7f5e6ddf8caba2174486fb5087ded6"
-  integrity sha512-BP6fRXtyj5thiMrHe9kLs05KWVUG108g/QY9UGHFqhjrnYM3Blwl0/+v49QqonxeYoK/fuzR/Wvu2TCmlAtHtA==
+libmuse@^0.0.91:
+  version "0.0.91"
+  resolved "https://registry.yarnpkg.com/libmuse/-/libmuse-0.0.91.tgz#0b268b320eee1db0ae9307d3371b538fadfc6aa7"
+  integrity sha512-kbYFmAvE8LDDufqT/hqbwnAJHFyRcQdTBopPdAJEuVo+PnWRp9UhzCPg0+C6sAUjfcuRQodDDVgw+KjIUGWuAw==
   dependencies:
     jsonpath-plus "7.2.0"
 


### PR DESCRIPTION
The server provides some strings. We can use an option to tell the server to give us content in a different language.

![Screenshot from 2024-03-12 13-19-46](https://github.com/vixalien/muzika/assets/37999241/e4097a53-5abd-4ac0-a1a7-cd3af0e1fed6)

However, the server supports a limited number of languages. The list can be seen at https://github.com/vixalien/muse/blob/main/locales/locales.json.

This PR will intelligently ask the server to provide content in your configured language (if available). If possible, it will also choose a similar language (`fr` for `fr-FR`). There is currently no option to directly configure which language is chose.

> [!NOTE]
> Server Side Translations are different from Client Side Translations. These are provided by `gettext` by writing strings in the `_("Translated String")` format.