### PR TITLE
Add `.Devel` symlink to symbolic icon

### DIFF
--- a/data/icons/hicolor/symbolic/apps/com.vixalien.muzika.Devel-symbolic.svg
+++ b/data/icons/hicolor/symbolic/apps/com.vixalien.muzika.Devel-symbolic.svg
@@ -1,0 +1,1 @@
+com.vixalien.muzika-symbolic.svg


### PR DESCRIPTION
Without this, the icon would show a fallback executable icon for MPRIS or anything else that shows symbolic icons.