### PR TITLE
Fix symbolic `.Devel` icon (again), remove `.desktop` from the id in the app's metainfo

### DIFF
--- a/data/com.vixalien.muzika.metainfo.xml.in.in
+++ b/data/com.vixalien.muzika.metainfo.xml.in.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-	<id>@app-id@.desktop</id>
+	<id>@app-id@</id>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0</project_license>
 	<name>Muzika</name>

--- a/data/icons/hicolor/symbolic/apps/com.vixalien.muzika.Devel-symbolic.svg
+++ b/data/icons/hicolor/symbolic/apps/com.vixalien.muzika.Devel-symbolic.svg
@@ -1,1 +1,0 @@
-com.vixalien.muzika-symbolic.svg

--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -8,5 +8,5 @@ symbolic_dir = join_paths('hicolor', 'symbolic', 'apps')
 install_data(
   join_paths(symbolic_dir, base_name + '-symbolic.svg'),
   install_dir: join_paths(muzika_datadir, 'icons', symbolic_dir),
-  rename: '@0@-symbolic.svg'.format(application_id)
+  rename: application_id + '-symbolic.svg'
 )

--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -7,5 +7,6 @@ install_data(
 symbolic_dir = join_paths('hicolor', 'symbolic', 'apps')
 install_data(
   join_paths(symbolic_dir, base_name + '-symbolic.svg'),
-  install_dir: join_paths(muzika_datadir, 'icons', symbolic_dir)
+  install_dir: join_paths(muzika_datadir, 'icons', symbolic_dir),
+  rename: '@0@-symbolic.svg'.format(application_id)
 )


### PR DESCRIPTION
Using a symlink doesn't work, so we should rename the SVG with meson instead.