### PR TITLE
feat: restart song with 'Previous' action

### DIFF
--- a/src/mpris.ts
+++ b/src/mpris.ts
@@ -380,15 +380,6 @@ export class MPRIS extends DBusInterface {
   }
 
   private _on_current_song_changed() {
-    // In repeat song mode, no metadata has changed if the player was
-    // already started
-    if (this.player.queue.repeat === RepeatMode.ONE) {
-      this._seeked(0);
-      if (this.player.queue.position > 0) {
-        return;
-      }
-    }
-
     // IDK
     this._on_player_model_changed(this.player.queue.list, 0, 0, 0);
   }

--- a/src/mpris.ts
+++ b/src/mpris.ts
@@ -379,25 +379,9 @@ export class MPRIS extends DBusInterface {
     return [false, ["/", "", ""]];
   }
 
-  private _on_current_song_changed() {
-    // IDK
-    this._on_player_model_changed(this.player.queue.list, 0, 0, 0);
-  }
-
   previous_state = new Map<string, unknown>();
 
-  _on_player_model_changed(
-    model: Gio.ListStore,
-    _pos: number,
-    _removed: number,
-    added: number,
-  ) {
-    // Don't update the properties if the model has completely changed.
-    // These changes will be applied once a new song starts playing.
-    if (added == model.n_items) {
-      return;
-    }
-
+  private _on_current_song_changed() {
     const properties: Record<string, GLib.Variant> = {
       Metadata: GLib.Variant.new("a{sv}", this._get_metadata()),
     };

--- a/src/mpris.ts
+++ b/src/mpris.ts
@@ -285,18 +285,6 @@ export class MPRIS extends DBusInterface {
         );
       }),
 
-      this.player.queue.connect("notify::can-play-previous", () => {
-        this._properties_changed(
-          this.MEDIA_PLAYER2_PLAYER_IFACE,
-          {
-            CanGoPrevious: GLib.Variant.new_boolean(
-              this.player.queue.can_play_previous,
-            ),
-          },
-          [],
-        );
-      }),
-
       this.player.connect("notify::seeking", () => {
         if (!this.player.seeking) {
           this._on_seek_finished(this, this.player.timestamp);
@@ -396,7 +384,7 @@ export class MPRIS extends DBusInterface {
     // already started
     if (this.player.queue.repeat === RepeatMode.ONE) {
       this._seeked(0);
-      if (this.player.queue.can_play_previous) {
+      if (this.player.queue.position > 0) {
         return;
       }
     }
@@ -427,12 +415,6 @@ export class MPRIS extends DBusInterface {
     if (has_next != this.previous_state.get("can_go_next")) {
       properties.CanGoNext = GLib.Variant.new_boolean(has_next);
       this.previous_state.set("can_go_next", has_next);
-    }
-
-    const has_previous = this.player.queue.can_play_previous;
-    if (has_previous != this.previous_state.get("can_go_previous")) {
-      properties.CanGoPrevious = GLib.Variant.new_boolean(has_previous);
-      this.previous_state.set("can_go_previous", has_next);
     }
 
     if (this.previous_state.get("can_play") != true) {
@@ -633,10 +615,7 @@ export class MPRIS extends DBusInterface {
           MinimumRate: GLib.Variant.new_double(1.0),
           MaximumRate: GLib.Variant.new_double(1.0),
           CanGoNext: GLib.Variant.new_boolean(this.player.queue.can_play_next),
-          CanGoPrevious: GLib.Variant.new(
-            "b",
-            this.player.queue.can_play_previous,
-          ),
+          CanGoPrevious: GLib.Variant.new_boolean(true),
           CanPlay: GLib.Variant.new_boolean(can_play),
           CanPause: GLib.Variant.new_boolean(can_play),
           CanSeek: GLib.Variant.new_boolean(true),

--- a/src/player/queue.ts
+++ b/src/player/queue.ts
@@ -12,7 +12,7 @@ import type { Queue as MuseQueue, QueueTrack } from "libmuse";
 
 import { ObjectContainer } from "../util/objectcontainer.js";
 import { AddActionEntries, build_action } from "src/util/action.js";
-import { Application } from "src/application.js";
+import { Application, get_player } from "src/application.js";
 import { list_model_to_array } from "src/util/list.js";
 import { ngettext } from "gettext";
 import { add_toast } from "src/util/window.js";
@@ -816,10 +816,14 @@ export class Queue extends GObject.Object {
   previous(): QueueTrack | null {
     const [position, track] = this.peek_previous();
 
-    if (position > -1) {
-      this.change_position(position);
-      this.emit("play");
+    const player = get_player();
+    if (player.timestamp >= 5 * 1000000 || position === -1) {
+      player.seek(0);
+      return this.current?.object ?? null;
     }
+
+    this.change_position(position);
+    this.emit("play");
 
     return track;
   }

--- a/src/player/queue.ts
+++ b/src/player/queue.ts
@@ -129,13 +129,6 @@ export class Queue extends GObject.Object {
             false,
             GObject.ParamFlags.READABLE,
           ),
-          "can-play-previous": GObject.param_spec_boolean(
-            "can-play-previous",
-            "Can play previous",
-            "Whether the previous song can be played",
-            false,
-            GObject.ParamFlags.READABLE,
-          ),
           repeat: GObject.param_spec_uint(
             "repeat",
             "Repeat",
@@ -290,11 +283,6 @@ export class Queue extends GObject.Object {
     return this.position < this.list.n_items - 1;
   }
 
-  get can_play_previous() {
-    if (this.repeat === RepeatMode.ALL) return true;
-    return this.position > 0;
-  }
-
   private _position = -1;
 
   get position() {
@@ -311,7 +299,6 @@ export class Queue extends GObject.Object {
       this.notify("current");
       this.notify("current-is-video");
       this.notify("can-play-next");
-      this.notify("can-play-previous");
     }
   }
 
@@ -492,7 +479,6 @@ export class Queue extends GObject.Object {
         name: "previous",
         parameter_type: null,
         activate: () => this.previous(),
-        bind_enabled: [this, "can-play-previous"],
       }),
     );
 
@@ -541,7 +527,6 @@ export class Queue extends GObject.Object {
     this.repeat = (this.repeat + 1) % 3;
 
     this.notify("can-play-next");
-    this.notify("can-play-previous");
   }
 
   private async active_chip_changed_cb() {
@@ -556,7 +541,6 @@ export class Queue extends GObject.Object {
 
       this.add_tracks("remaining", queue.tracks);
 
-      this.notify("can-play-previous");
       this.notify("can-play-next");
     }
   }


### PR DESCRIPTION
 Match the common behavior of the 'Previous' action across many music apps such as Spotify/YT Music, where the song is restarted if the 'Previous' is activated on the first song of the queue, or after a 5 second "grace period"

I'm not sure I like accessing the Player within the Queue, but this is the easiest way to implement this. We can reiterate if needed.

Closes #193